### PR TITLE
Add Github Action for Publishing to Comfy Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to Comfy registry
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  issues: write
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'tpc2233' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Publish Custom Node
+        uses: Comfy-Org/publish-node-action@v1
+        with:
+          ## Add your own personal access token to your Github Repository secrets and reference it here.
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds a Github Action (publish-node-action) that will publish an updated version of your custom node to the [registry](https://registry.comfy.org/) whenever the `pyproject.toml` file changes. The pyproject.toml defines the custom node version you want to publish (added in another PR). Make sure you update the version number in `pyproject.toml` when you make a change that should be published to everyone!

Action Required:

- [ ] Make sure the trigger branch (`master` or `main`) in `publish.yaml` matches the branch you want to use as the publishing branch. It will only trigger when the pyproject.toml gets updated on that branch.
- [ ] Create an api key on the Registry for publishing from Github. [Instructions](https://docs.comfy.org/registry/publishing#create-an-api-key-for-publishing).
- [ ] Add it to your Github Repository Secrets as `REGISTRY_ACCESS_TOKEN`.

Please message me on Discord at robinken or join our [server](https://discord.com/invite/comfyorg) server if you have any questions!